### PR TITLE
fix: listen on ipv6

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ async function start() {
   try {
     // eslint-disable-next-line no-console
     console.log(`Starting server http://localhost:${config.port} ...`);
-    await server.listen({ port: config.port, host: '0.0.0.0' });
+    await server.listen({ port: config.port, host: '::' });
   } catch (err) {
     server.log.error(err);
     process.exit(1);


### PR DESCRIPTION
> Or specify :: to accept connections on all IPv6 addresses, and, if the operating system supports it, also on all IPv4 addresses.

https://www.fastify.io/docs/latest/Guides/Getting-Started/#your-first-server


Judging by this IPv4 should still work as expected.